### PR TITLE
added dns_domain in neutron.conf and dns as extension_driver to ml2_c…

### DIFF
--- a/change_nova_dhcpdomain.yml
+++ b/change_nova_dhcpdomain.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: compute
-  name: Change DHCP Domain in nova.conf
+  name: Change DHCP/DNS Domain in nova and neutron
   become: yes
   vars_files:
     - vars.yml
@@ -17,11 +17,21 @@
     - name: Change dhcp_domain in neutron dhcp_agent.ini
       lineinfile:
         dest: /etc/neutron/dhcp_agent.ini
-        regexp: '^dhcp_domain='
-        line: 'dhcp_domain={{ nova_domain }}'
+        regexp: '^dhcp_domain ='
+        line: 'dhcp_domain = {{ nova_domain }}'
+    - name: Change dns_domain in neutron neutron.conf
+      lineinfile:
+        dest: /etc/neutron/neutron.conf
+        regexp: '^dns_domain ='
+        line: 'dns_domain = {{ nova_domain }}.'
+    - name: Change extension_drivers in neutron ml2 plugins
+      lineinfile:
+        dest: /etc/neutron/plugins/ml2/ml2_conf.ini
+        regexp: '^extension_drivers ='
+        line: 'extension_drivers = qos,port_security,dns'
 
 - hosts: controller
-  name: Change DHCP Domain in nova.conf
+  name: Change DHCP/DNS Domain in nova and neutron
   become: yes
   vars_files:
     - vars.yml
@@ -38,9 +48,23 @@
     - name: Change dhcp_domain in neutron dhcp_agent.ini
       lineinfile:
         dest: /etc/neutron/dhcp_agent.ini
-        regexp: '^dhcp_domain='
-        line: 'dhcp_domain={{ nova_domain }}'
-    - name: restart openstack-nova-api
+        regexp: '^dhcp_domain ='
+        line: 'dhcp_domain = {{ nova_domain }}'
+    - name: Change dns_domain in neutron.conf
+      lineinfile:
+        dest: /etc/neutron/neutron.conf
+        regexp: '^dns_domain ='
+        line: 'dns_domain = {{ nova_domain }}.'
+    - name: Change extension_drivers in neutron ml2 plugins
+      lineinfile:
+        dest: /etc/neutron/plugins/ml2/ml2_conf.ini
+        regexp: '^extension_drivers ='
+        line: 'extension_drivers = qos,port_security,dns'
+    - name: restart neutron-server
+      service:
+        name: neutron-server
+        state: restarted
+    - name: restart neutron-dhcp-agent
       service:
         name: neutron-dhcp-agent
         state: restarted


### PR DESCRIPTION
Hi Kevin,
To keep everything together, here is a formal pull request with my additions of dns_domain in neutron.conf and also adding "dns" as an extension_drivers in ml2_conf.ini (as discussed at the beginning of this how-to doc: https://docs.openstack.org/mitaka/networking-guide/config-dns-int.html).
As mentioned in email, this still doesn't fix the smaller /etc/resolv.conf issue. I'm thinking to make it all fully work, this might need an integrated Designate/dns-as-a-service implementation on the overcloud.
Best,
Ben